### PR TITLE
Buildkite CI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ precompiled Linux binaries are statically linked.
 ### CI/CD
 
 You can also use sshx in continuous integration workflows to help debug tricky
-issues, like in GitHub Actions.
+issues, like in GitHub Actions or Buildkite.
 
+#### GitHub Actions
 ```yaml
 name: CI
 on: push
@@ -45,6 +46,17 @@ jobs:
       # ... other steps ...
 
       - run: curl -sSf https://sshx.io/get | sh && sshx
+      #      ^
+      #      └ This will open a remote terminal session and print the URL. It
+      #        should take under a second.
+```
+
+#### Buildkite
+```yaml
+steps:
+  - label: "Let's collaborate! :rocket:"
+    command: >
+      curl -sSf https://sshx.io/get | sh && sshx
       #      ^
       #      └ This will open a remote terminal session and print the URL. It
       #        should take under a second.


### PR DESCRIPTION
This can easily be used in Buildkite too, so I added an example to the README on how folks can achieve this using Buildkite's steps.

I added L4 headers so that folks can link to their relevant CI provider.