### PR TITLE
Set deadpool config size to 4 conns

### DIFF
--- a/crates/sshx-server/src/state/mesh.rs
+++ b/crates/sshx-server/src/state/mesh.rs
@@ -41,7 +41,7 @@ impl StorageMesh {
     pub fn new(redis_url: &str, host: Option<&str>) -> Result<Self> {
         let redis = deadpool_redis::Config::from_url(redis_url)
             .builder()?
-            .max_size(2048)
+            .max_size(4)
             .wait_timeout(Some(Duration::from_secs(5)))
             .runtime(deadpool_redis::Runtime::Tokio1)
             .build()?;


### PR DESCRIPTION
This is a change for server connection pool performance. We only use the Redis connection pool to optimize immediate `GET` and `SET` operations, which should be very fast, so it doesn't make sense to keeping too many idle connections in the pool.

Deadpool's connection pool only configures the number of slots that are maintained for connections to be recycled, so this is fine. Unlike other pools, this will still create more Redis connections if we hit the max pool size.