### PR TITLE
Revert "Add Buffer layer to outer service for efficiency"

### DIFF
--- a/crates/sshx-server/src/listen.rs
+++ b/crates/sshx-server/src/listen.rs
@@ -58,8 +58,6 @@ pub(crate) async fn start_server(
             }
         },
     );
-    let svc = ServiceBuilder::new().buffer(8).service(svc).boxed_clone();
-
     let make_svc = make_service_fn(move |_| {
         let svc = svc.clone();
         async { Ok::<_, std::convert::Infallible>(svc) }


### PR DESCRIPTION
This reverts commit 2de83337750cad6249baa46053eb89e26597160b.

I didn't realize this, but the `Buffer` layer actually limits the _concurrency_ of the inner service because semaphore permits are not dropped until the request actually finishes execution in the async `call()` handler of the inner service. This means that we started limiting concurrent connections drastically.

In particular this broke sshx 9 hours ago for several users. Ahhh. At least I was running a lot of replicas around the world, which mitigated it a little.