### PR TITLE
Add a 60-second client reconnect

### DIFF
--- a/crates/sshx/src/controller.rs
+++ b/crates/sshx/src/controller.rs
@@ -151,7 +151,6 @@ impl Controller {
                         .context("server message is missing")?
                 }
                 _ = &mut reconnect => {
-                    dbg!("reconnecting");
                     return Ok(()); // Reconnect to the server.
                 }
             };

--- a/crates/sshx/src/controller.rs
+++ b/crates/sshx/src/controller.rs
@@ -1,6 +1,7 @@
 //! Network gRPC client allowing server control of terminals.
 
 use std::collections::HashMap;
+use std::pin::pin;
 
 use anyhow::{Context, Result};
 use sshx_core::proto::{
@@ -20,6 +21,9 @@ use crate::runner::{Runner, ShellData};
 
 /// Interval for sending empty heartbeat messages to the server.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Interval to automatically re-establish connections.
+const RECONNECT_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Handles a single session's communication with the remote server.
 pub struct Controller {
@@ -129,6 +133,7 @@ impl Controller {
 
         let mut interval = time::interval(HEARTBEAT_INTERVAL);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut reconnect = pin!(time::sleep(RECONNECT_INTERVAL));
         loop {
             let message = tokio::select! {
                 _ = interval.tick() => {
@@ -144,6 +149,10 @@ impl Controller {
                     item.context("server closed connection")??
                         .server_message
                         .context("server message is missing")?
+                }
+                _ = &mut reconnect => {
+                    dbg!("reconnecting");
+                    return Ok(()); // Reconnect to the server.
                 }
             };
 

--- a/crates/sshx/src/controller.rs
+++ b/crates/sshx/src/controller.rs
@@ -22,8 +22,8 @@ use crate::runner::{Runner, ShellData};
 /// Interval for sending empty heartbeat messages to the server.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 
-/// Interval to automatically re-establish connections.
-const RECONNECT_INTERVAL: Duration = Duration::from_secs(10);
+/// Interval to automatically reestablish connections.
+const RECONNECT_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Handles a single session's communication with the remote server.
 pub struct Controller {

--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,7 @@
 app = "sshx"
 primary_region = "ewr"
 kill_signal = "SIGINT"
-kill_timeout = 5
+kill_timeout = 90
 
 [experimental]
   auto_rollback = true


### PR DESCRIPTION
This improves reliability in most cases, such as when network errors are not reported immediately to the streaming request client. It's at the expense of a brief blip during every reconnection. But this should hardly be noticeable, assuming real-time RTL, it would affect ~0.2% of interactions.