### PR TITLE
Add --name option, default user@hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,7 +1101,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -1319,6 +1319,15 @@ name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1695,7 +1704,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sshx"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes",
  "ansi_term",
@@ -1713,11 +1722,12 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "whoami",
 ]
 
 [[package]]
 name = "sshx-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "prost",
  "rand",
@@ -1728,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "sshx-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1802,7 +1812,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]
@@ -2234,6 +2244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2350,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+dependencies = [
+ "redox_syscall 0.4.1",
+ "wasite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Eric Zhang <ekzhang1@gmail.com>"]
 license = "MIT"
 description = "A secure web-based, collaborative terminal."
@@ -17,7 +17,7 @@ clap = { version = "4.4.2", features = ["derive", "env"] }
 prost = "0.12.0"
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sshx-core = { version = "0.2.3", path = "crates/sshx-core" }
+sshx-core = { version = "0.2.4", path = "crates/sshx-core" }
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tonic = { version = "0.10.0", features = ["tls", "tls-webpki-roots"] }

--- a/crates/sshx-core/proto/sshx.proto
+++ b/crates/sshx-core/proto/sshx.proto
@@ -40,6 +40,7 @@ message TerminalSize {
 message OpenRequest {
   string origin = 1;         // Web origin of the server.
   bytes encrypted_zeros = 2; // Encrypted zero block, for client verification.
+  string name = 3;           // Name of the session (user@hostname).
 }
 
 // Details of a newly-created sshx session.
@@ -101,6 +102,7 @@ message SerializedSession {
   map<uint32, SerializedShell> shells = 2;
   uint32 next_sid = 3;
   uint32 next_uid = 4;
+  string name = 5;
 }
 
 message SerializedShell {

--- a/crates/sshx-server/src/grpc.rs
+++ b/crates/sshx-server/src/grpc.rs
@@ -55,6 +55,7 @@ impl SshxService for GrpcServer {
             None => {
                 let metadata = Metadata {
                     encrypted_zeros: request.encrypted_zeros,
+                    name: request.name,
                 };
                 self.0.insert(&name, Arc::new(Session::new(metadata)));
             }

--- a/crates/sshx-server/src/session.rs
+++ b/crates/sshx-server/src/session.rs
@@ -30,6 +30,9 @@ const SHELL_STORED_BYTES: u64 = 1 << 21; // 2 MiB
 pub struct Metadata {
     /// Used to validate that clients have the correct encryption key.
     pub encrypted_zeros: Bytes,
+
+    /// Name of the session (human-readable).
+    pub name: String,
 }
 
 /// In-memory state for a single sshx session.

--- a/crates/sshx-server/src/session/snapshot.rs
+++ b/crates/sshx-server/src/session/snapshot.rs
@@ -61,6 +61,7 @@ impl Session {
                 .collect(),
             next_sid: ids.0 .0,
             next_uid: ids.1 .0,
+            name: self.metadata().name.clone(),
         };
         let data = message.encode_to_vec();
         ensure!(data.len() < MAX_SNAPSHOT_SIZE, "snapshot too large");
@@ -73,6 +74,7 @@ impl Session {
         let message = SerializedSession::decode(&*data)?;
         let metadata = Metadata {
             encrypted_zeros: message.encrypted_zeros,
+            name: message.name,
         };
 
         let session = Self::new(metadata);

--- a/crates/sshx-server/src/web/protocol.rs
+++ b/crates/sshx-server/src/web/protocol.rs
@@ -46,7 +46,7 @@ pub struct WsUser {
 #[serde(rename_all = "camelCase")]
 pub enum WsServer {
     /// Initial server message, with the user's ID and session metadata.
-    Hello(Uid),
+    Hello(Uid, String),
     /// The user's authentication was invalid.
     InvalidAuth(),
     /// A snapshot of all current users in the session.

--- a/crates/sshx-server/src/web/socket.rs
+++ b/crates/sshx-server/src/web/socket.rs
@@ -90,12 +90,13 @@ async fn handle_socket(socket: &mut WebSocket, session: Arc<Session>) -> Result<
         })
     }
 
+    let metadata = session.metadata();
     let user_id = session.counter().next_uid();
     session.sync_now();
-    send(socket, WsServer::Hello(user_id)).await?;
+    send(socket, WsServer::Hello(user_id, metadata.name.clone())).await?;
 
     match recv(socket).await? {
-        Some(WsClient::Authenticate(bytes)) if bytes == session.metadata().encrypted_zeros => {}
+        Some(WsClient::Authenticate(bytes)) if bytes == metadata.encrypted_zeros => {}
         _ => {
             send(socket, WsServer::InvalidAuth()).await?;
             return Ok(());

--- a/crates/sshx-server/tests/common/mod.rs
+++ b/crates/sshx-server/tests/common/mod.rs
@@ -154,7 +154,7 @@ impl ClientSocket {
         let flush_task = async {
             while let Some(msg) = self.recv().await {
                 match msg {
-                    WsServer::Hello(user_id) => self.user_id = user_id,
+                    WsServer::Hello(user_id, _) => self.user_id = user_id,
                     WsServer::InvalidAuth() => panic!("invalid authentication"),
                     WsServer::Users(users) => self.users = BTreeMap::from_iter(users),
                     WsServer::UserDiff(id, maybe_user) => {

--- a/crates/sshx-server/tests/simple.rs
+++ b/crates/sshx-server/tests/simple.rs
@@ -14,6 +14,7 @@ async fn test_rpc() -> Result<()> {
     let req = OpenRequest {
         origin: "sshx.io".into(),
         encrypted_zeros: Encrypt::new("").zeros().into(),
+        name: String::new(),
     };
     let resp = client.open(req).await?;
     assert!(!resp.into_inner().name.is_empty());

--- a/crates/sshx-server/tests/snapshot.rs
+++ b/crates/sshx-server/tests/snapshot.rs
@@ -16,7 +16,7 @@ pub mod common;
 async fn test_basic_restore() -> Result<()> {
     let server = TestServer::new().await;
 
-    let mut controller = Controller::new(&server.endpoint(), Runner::Echo).await?;
+    let mut controller = Controller::new(&server.endpoint(), "", Runner::Echo).await?;
     let name = controller.name().to_owned();
     let key = controller.encryption_key().to_owned();
     tokio::spawn(async move { controller.run().await });

--- a/crates/sshx-server/tests/with_client.rs
+++ b/crates/sshx-server/tests/with_client.rs
@@ -14,7 +14,7 @@ pub mod common;
 #[tokio::test]
 async fn test_handshake() -> Result<()> {
     let server = TestServer::new().await;
-    let controller = Controller::new(&server.endpoint(), Runner::Echo).await?;
+    let controller = Controller::new(&server.endpoint(), "", Runner::Echo).await?;
     controller.close().await?;
     Ok(())
 }
@@ -23,7 +23,7 @@ async fn test_handshake() -> Result<()> {
 async fn test_command() -> Result<()> {
     let server = TestServer::new().await;
     let runner = Runner::Shell("/bin/bash".into());
-    let mut controller = Controller::new(&server.endpoint(), runner).await?;
+    let mut controller = Controller::new(&server.endpoint(), "", runner).await?;
 
     let session = server
         .state()
@@ -69,7 +69,7 @@ async fn test_ws_missing() -> Result<()> {
 async fn test_ws_basic() -> Result<()> {
     let server = TestServer::new().await;
 
-    let mut controller = Controller::new(&server.endpoint(), Runner::Echo).await?;
+    let mut controller = Controller::new(&server.endpoint(), "", Runner::Echo).await?;
     let name = controller.name().to_owned();
     let key = controller.encryption_key().to_owned();
     tokio::spawn(async move { controller.run().await });
@@ -101,7 +101,7 @@ async fn test_ws_basic() -> Result<()> {
 async fn test_ws_resize() -> Result<()> {
     let server = TestServer::new().await;
 
-    let mut controller = Controller::new(&server.endpoint(), Runner::Echo).await?;
+    let mut controller = Controller::new(&server.endpoint(), "", Runner::Echo).await?;
     let name = controller.name().to_owned();
     let key = controller.encryption_key().to_owned();
     tokio::spawn(async move { controller.run().await });
@@ -145,7 +145,7 @@ async fn test_ws_resize() -> Result<()> {
 async fn test_users_join() -> Result<()> {
     let server = TestServer::new().await;
 
-    let mut controller = Controller::new(&server.endpoint(), Runner::Echo).await?;
+    let mut controller = Controller::new(&server.endpoint(), "", Runner::Echo).await?;
     let name = controller.name().to_owned();
     let key = controller.encryption_key().to_owned();
     tokio::spawn(async move { controller.run().await });
@@ -174,7 +174,7 @@ async fn test_users_join() -> Result<()> {
 async fn test_users_metadata() -> Result<()> {
     let server = TestServer::new().await;
 
-    let mut controller = Controller::new(&server.endpoint(), Runner::Echo).await?;
+    let mut controller = Controller::new(&server.endpoint(), "", Runner::Echo).await?;
     let name = controller.name().to_owned();
     let key = controller.encryption_key().to_owned();
     tokio::spawn(async move { controller.run().await });
@@ -199,7 +199,7 @@ async fn test_users_metadata() -> Result<()> {
 async fn test_chat_messages() -> Result<()> {
     let server = TestServer::new().await;
 
-    let mut controller = Controller::new(&server.endpoint(), Runner::Echo).await?;
+    let mut controller = Controller::new(&server.endpoint(), "", Runner::Echo).await?;
     let name = controller.name().to_owned();
     let key = controller.encryption_key().to_owned();
     tokio::spawn(async move { controller.run().await });

--- a/crates/sshx/Cargo.toml
+++ b/crates/sshx/Cargo.toml
@@ -26,3 +26,4 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+whoami = { version = "1.5.1", default-features = false }

--- a/crates/sshx/src/main.rs
+++ b/crates/sshx/src/main.rs
@@ -62,7 +62,7 @@ async fn start(args: Args) -> Result<()> {
             // Trim domain information like .lan or .local
             let host = host.split('.').next().unwrap_or(&host);
             name += "@";
-            name += &host;
+            name += host;
         }
         name
     });

--- a/crates/sshx/src/main.rs
+++ b/crates/sshx/src/main.rs
@@ -22,6 +22,10 @@ struct Args {
     /// Quiet mode, only prints the URL to stdout.
     #[clap(short, long)]
     quiet: bool,
+
+    /// Session name displayed in the title (defaults to user@hostname).
+    #[clap(long)]
+    name: Option<String>,
 }
 
 fn print_greeting(shell: &str, controller: &Controller) {
@@ -52,8 +56,19 @@ async fn start(args: Args) -> Result<()> {
         None => get_default_shell().await,
     };
 
+    let name = args.name.unwrap_or_else(|| {
+        let mut name = whoami::username();
+        if let Ok(host) = whoami::fallible::hostname() {
+            // Trim domain information like .lan or .local
+            let host = host.split('.').next().unwrap_or(&host);
+            name += "@";
+            name += &host;
+        }
+        name
+    });
+
     let runner = Runner::Shell(shell.clone());
-    let mut controller = Controller::new(&args.server, runner).await?;
+    let mut controller = Controller::new(&args.server, &name, runner).await?;
     if args.quiet {
         println!("{}", controller.url());
     } else {

--- a/src/lib/Session.svelte
+++ b/src/lib/Session.svelte
@@ -138,7 +138,6 @@
       onMessage(message) {
         if (message.hello) {
           userId = message.hello[0];
-          console.log(message.hello);
           dispatch("receiveName", message.hello[1]);
           makeToast({
             kind: "success",

--- a/src/lib/Session.svelte
+++ b/src/lib/Session.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { onDestroy, onMount, tick, beforeUpdate, afterUpdate } from "svelte";
+  import {
+    onDestroy,
+    onMount,
+    tick,
+    beforeUpdate,
+    afterUpdate,
+    createEventDispatcher,
+  } from "svelte";
   import { fade } from "svelte/transition";
   import { debounce, throttle } from "lodash-es";
 
@@ -23,6 +30,8 @@
   import { settings } from "./settings";
 
   export let id: string;
+
+  const dispatch = createEventDispatcher<{ receiveName: string }>();
 
   // The magic numbers "left" and "top" are used to approximately center the
   // terminal at the time that it is first created.
@@ -128,7 +137,9 @@
     srocket = new Srocket<WsServer, WsClient>(`/api/s/${id}`, {
       onMessage(message) {
         if (message.hello) {
-          userId = message.hello;
+          userId = message.hello[0];
+          console.log(message.hello);
+          dispatch("receiveName", message.hello[1]);
           makeToast({
             kind: "success",
             message: `Connected to the server.`,

--- a/src/lib/protocol.ts
+++ b/src/lib/protocol.ts
@@ -18,7 +18,7 @@ export type WsUser = {
 
 /** Server message type, see the Rust version. */
 export type WsServer = {
-  hello?: Uid;
+  hello?: [Uid, string];
   invalidAuth?: [];
   users?: [Uid, WsUser][];
   userDiff?: [Uid, WsUser | null];

--- a/src/routes/s/[id]/+page.svelte
+++ b/src/routes/s/[id]/+page.svelte
@@ -2,9 +2,13 @@
   import { page } from "$app/stores";
 
   import Session from "$lib/Session.svelte";
+
+  let title: string = "Remote Terminal | sshx";
 </script>
 
 <svelte:head>
+  <title>{title}</title>
+
   <style>
     body {
       overscroll-behavior: none;
@@ -12,4 +16,11 @@
   </style>
 </svelte:head>
 
-<Session id={$page.params.id} />
+<Session
+  id={$page.params.id}
+  on:receiveName={({ detail: sessionName }) => {
+    if (sessionName) {
+      title = `${sessionName} | sshx`;
+    }
+  }}
+/>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
 
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify("0.2.3-" + commitHash),
+    __APP_VERSION__: JSON.stringify("0.2.4-" + commitHash),
   },
 
   plugins: [sveltekit()],


### PR DESCRIPTION
This appears in the title of the browser tab. If not specified, it will default to detecting the user and hostname of your machine using OS APIs.

This change is backwards-compatible and forwards-compatible between old clients and old server versions.

Resolves #90 and resolves #85.

Also bumps version to 0.2.4.