### PR TITLE
Change INITIAL_ZOOM to 1.0

### DIFF
--- a/src/lib/action/touchZoom.ts
+++ b/src/lib/action/touchZoom.ts
@@ -51,7 +51,7 @@ function debounce<T extends (...args: any[]) => void>(fn: T, ms = 0) {
 
 const MIN_ZOOM = 0.35;
 const MAX_ZOOM = 2;
-export const INITIAL_ZOOM = 0.9;
+export const INITIAL_ZOOM = 1.0;
 
 export class TouchZoom {
   #node: HTMLElement;


### PR DESCRIPTION
because of the scale being set to 0.9, the text is blurry on my 1080p display

![image](https://github.com/user-attachments/assets/582784d2-11ba-45f3-8547-77422a7eeb45)

changing it to 1.0 makes the text render correctly (much sharper):

![image](https://github.com/user-attachments/assets/17be7de3-889c-489e-97ac-3f86f9300206)

alternatively, we could also change the zooming logic so it's possible to get to 1.0 (currently, the increment doesn't align with 1.0 ever on desktop)