### PR TITLE
Fix flash of "read-only" badge on initial page load

### DIFF
--- a/src/lib/ui/Toolbar.svelte
+++ b/src/lib/ui/Toolbar.svelte
@@ -10,7 +10,7 @@
   import logo from "$lib/assets/logo.svg";
 
   export let connected: boolean;
-  export let hasWriteAccess: boolean | null;
+  export let hasWriteAccess: boolean | undefined;
   export let newMessages: boolean;
 
   const dispatch = createEventDispatcher<{
@@ -37,7 +37,7 @@
         disabled={!connected || !hasWriteAccess}
         title={!connected
           ? "Not connected"
-          : !hasWriteAccess
+          : hasWriteAccess === false // Only show the "No write access" title after confirming read-only mode.
           ? "No write access"
           : "Create new terminal"}
       >


### PR DESCRIPTION
Because of how the read-only mode is implemented on the frontend currently, there's a brief flash of the "read-only" bug when the page is first loaded and before the `canWrite` value is received. This is only a display bug.

Fixed in this change by not displaying the badge until we've confirmed that `canWrite === false`.

<img width="290" alt="image" src="https://github.com/user-attachments/assets/52d4a31c-fbd3-4c36-921a-44be3da7a40e" />