### PR TITLE
Remove argon2 dependency on esm.sh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@rgossiaux/svelte-headlessui": "^2.0.0",
         "@tldraw/vec": "^1.9.2",
         "@use-gesture/vanilla": "^10.2.27",
+        "argon2-browser": "^1.18.0",
         "buffer": "^6.0.3",
         "cbor-x": "^1.6.0",
         "firacode": "^6.2.0",
@@ -44,7 +45,8 @@
         "tailwindcss": "^3.3.3",
         "tslib": "^2.6.2",
         "typescript": "~5.2.2",
-        "vite": "^4.4.9"
+        "vite": "^4.4.9",
+        "vite-plugin-wasm": "^3.4.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1123,6 +1125,11 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
+    },
+    "node_modules/argon2-browser": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/argon2-browser/-/argon2-browser-1.18.0.tgz",
+      "integrity": "sha512-ImVAGIItnFnvET1exhsQB7apRztcoC5TnlSqernMJDUjbc/DLq3UEYeXFrLPrlaIl8cVfwnXb6wX2KpFf2zxHw=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4396,6 +4403,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.4.1.tgz",
+      "integrity": "sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5 || ^6"
       }
     },
     "node_modules/vitefu": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,7 @@
         "tailwindcss": "^3.3.3",
         "tslib": "^2.6.2",
         "typescript": "~5.2.2",
-        "vite": "^4.4.9",
-        "vite-plugin-wasm": "^3.4.1"
+        "vite": "^4.4.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4403,15 +4402,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-wasm": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.4.1.tgz",
-      "integrity": "sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==",
-      "dev": true,
-      "peerDependencies": {
-        "vite": "^2 || ^3 || ^4 || ^5 || ^6"
       }
     },
     "node_modules/vitefu": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@rgossiaux/svelte-headlessui": "^2.0.0",
     "@tldraw/vec": "^1.9.2",
     "@use-gesture/vanilla": "^10.2.27",
+    "argon2-browser": "^1.18.0",
     "buffer": "^6.0.3",
     "cbor-x": "^1.6.0",
     "firacode": "^6.2.0",
@@ -50,6 +51,7 @@
     "tailwindcss": "^3.3.3",
     "tslib": "^2.6.2",
     "typescript": "~5.2.2",
-    "vite": "^4.4.9"
+    "vite": "^4.4.9",
+    "vite-plugin-wasm": "^3.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "tailwindcss": "^3.3.3",
     "tslib": "^2.6.2",
     "typescript": "~5.2.2",
-    "vite": "^4.4.9",
-    "vite-plugin-wasm": "^3.4.1"
+    "vite": "^4.4.9"
   }
 }


### PR DESCRIPTION
Resolves #111. This hasn't been an issue in the past year or more, but esm.sh is a bit unstable today and it revealed that we probably don't really need to keep using this external CDN.