### PR TITLE
fix static dir in doc

### DIFF
--- a/crates/sshx-server/src/lib.rs
+++ b/crates/sshx-server/src/lib.rs
@@ -5,7 +5,7 @@
 //! using a hybrid Hyper service, split between a Tonic gRPC handler and an Axum
 //! web listener.
 //!
-//! Most web requests are routed directly to static files located in the `dist/`
+//! Most web requests are routed directly to static files located in the `build/`
 //! folder relative to where this binary is running, allowing the frontend to be
 //! separately developed from the server.
 


### PR DESCRIPTION
Seems now `npm run build` puts generated files in the `build/` dir.

BTW, should the notice that we should run `npm run build` before running `cargo r --bin sshx-server` be added to the `README`?