### PR TITLE
Add support for arm64 windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ curl -sSf https://sshx.io/get | sh
 Supports Linux and MacOS on x86_64 and ARM64 architectures, as well as embedded
 ARMv6 and ARMv7-A systems. The Linux binaries are statically linked.
 
-For Windows, there are binaries for x86_64 and x86, linked to MSVC for maximum
-compatibility.
+For Windows, there are binaries for x86_64, x86, and ARM64, linked to MSVC for
+maximum compatibility.
 
 If you just want to try it out without installing, use:
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,8 +41,7 @@ cross build --release --target x86_64-unknown-freebsd
 # *-pc-windows-msvc: for Windows, requires cargo-xwin
 XWIN_ARCH=x86,x86_64,aarch64 cargo xwin build -p sshx --release --target x86_64-pc-windows-msvc
 XWIN_ARCH=x86,x86_64,aarch64 cargo xwin build -p sshx --release --target i686-pc-windows-msvc
-# Does not work, see https://github.com/rust-cross/cargo-xwin/issues/76
-# XWIN_ARCH=x86,x86_64,aarch64 cargo xwin build -p sshx --release --target aarch64-pc-windows-msvc
+XWIN_ARCH=x86,x86_64,aarch64 cargo xwin build -p sshx --release --target aarch64-pc-windows-msvc --cross-compiler clang
 
 temp=$(mktemp)
 targets=(
@@ -55,7 +54,7 @@ targets=(
   x86_64-unknown-freebsd
   x86_64-pc-windows-msvc
   i686-pc-windows-msvc
-  # aarch64-pc-windows-msvc
+  aarch64-pc-windows-msvc
 )
 for target in "${targets[@]}"
 do

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -223,10 +223,10 @@
           href="https://sshx.s3.amazonaws.com/sshx-i686-pc-windows-msvc.zip"
           >Windows x86</DownloadLink
         >
-        <!-- <DownloadLink
+        <DownloadLink
           href="https://sshx.s3.amazonaws.com/sshx-aarch64-pc-windows-msvc.zip"
           >Windows ARM64</DownloadLink
-        > -->
+        >
       </div>
     </div>
   </section>


### PR DESCRIPTION
This is thanks to the new work on cargo-xwin (https://github.com/rust-cross/cargo-xwin/issues/76) that enables Clang as a cross-compiler, allowing ring and rustls to build on ARM64 Windows.

Resolves #119 