### PR TITLE
Fix RFC 8441 (WebSocket over HTTP/2) issue

### DIFF
--- a/crates/sshx-server/src/web.rs
+++ b/crates/sshx-server/src/web.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use axum::routing::{get, get_service};
+use axum::routing::{any, get_service};
 use axum::Router;
 use tower_http::services::{ServeDir, ServeFile};
 
@@ -30,5 +30,5 @@ pub fn app() -> Router<Arc<ServerState>> {
 
 /// Routes for the backend web API server.
 fn backend() -> Router<Arc<ServerState>> {
-    Router::new().route("/s/{name}", get(socket::get_session_ws))
+    Router::new().route("/s/{name}", any(socket::get_session_ws))
 }


### PR DESCRIPTION
This resolves #122 after a change in Axum 0.8.0. See the issue for an explanation of what happened.